### PR TITLE
Adds markdown formatter to render preflight results

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@
     "unicorn/prevent-abbreviations": "off",
     "unicorn/no-process-exit": "off",
     "unicorn/import-style": "off",
+    "unicorn/prefer-node-protocol": "off",
     "unicorn/prefer-module": "off",
     "node/no-missing-import": "off",
     "node/no-unsupported-features/es-syntax": [

--- a/__tests__/__fixtures__/markdown-results.sarif
+++ b/__tests__/__fixtures__/markdown-results.sarif
@@ -1,0 +1,225 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "properties": {
+    "project": {
+      "name": "cli",
+      "version": "0.0.1",
+      "repository": {
+        "totalCommits": 27,
+        "totalFiles": 20,
+        "age": "4 days",
+        "activeDays": "4",
+        "linesOfCode": {
+          "types": [
+            {
+              "total": 255,
+              "extension": "ts"
+            },
+            {
+              "total": 167,
+              "extension": "js"
+            }
+          ],
+          "total": 422
+        }
+      }
+    },
+    "cli": {
+      "configHash": "26099139cc4ef53ea673f75dfe17aa9e",
+      "config": {
+        "$schema": "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+        "excludePaths": [],
+        "plugins": [
+          "checkup-plugin-embroider"
+        ],
+        "tasks": {}
+      },
+      "version": "1.0.0-beta.11",
+      "schema": 1,
+      "options": [
+        "--config.$schema",
+        "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+        "--config.plugins",
+        "checkup-plugin-embroider",
+        "--cwd",
+        "/Users/foo/stitch",
+        "--pluginBaseDir",
+        "/Users/foo/stitch/lib"
+      ]
+    },
+    "analyzedFiles": [
+      ".DS_Store",
+      ".eslintcache",
+      ".eslintignore",
+      ".eslintrc",
+      ".github/workflows/ci-build.yml",
+      ".gitignore",
+      ".prettierrc.js",
+      ".vscode/settings.json",
+      "CHANGELOG.md",
+      "README.md",
+      "RELEASE.md",
+      "__tests__/__fixtures__/markdown-results.sarif",
+      "__tests__/cli-test.ts",
+      "__tests__/markdown-formatter-test.ts",
+      "__tests__/tsconfig.json",
+      "bin/stitch.js",
+      "jest.config.js",
+      "jest.setup.ts",
+      "lib/checkup-plugin-embroider/index.d.ts",
+      "lib/checkup-plugin-embroider/index.d.ts.map",
+      "lib/checkup-plugin-embroider/index.js",
+      "lib/checkup-plugin-embroider/index.js.map",
+      "lib/checkup-plugin-embroider/package.json",
+      "lib/checkup-plugin-embroider/tasks/dependency-check-task.d.ts",
+      "lib/checkup-plugin-embroider/tasks/dependency-check-task.d.ts.map",
+      "lib/checkup-plugin-embroider/tasks/dependency-check-task.js",
+      "lib/checkup-plugin-embroider/tasks/dependency-check-task.js.map",
+      "lib/markdown-formatter.d.ts",
+      "lib/markdown-formatter.d.ts.map",
+      "lib/markdown-formatter.js",
+      "lib/markdown-formatter.js.map",
+      "lib/stitch.d.ts",
+      "lib/stitch.d.ts.map",
+      "lib/stitch.js",
+      "lib/stitch.js.map",
+      "node_modules/.bin/JSONStream",
+      "node_modules/.bin/acorn",
+      "node_modules/.bin/atob",
+      "node_modules/.bin/autoprefixer",
+      "node_modules/.bin/browserslist",
+      "node_modules/.bin/checkup",
+      "node_modules/.bin/checkup-plugin",
+      "node_modules/.bin/cssesc",
+      "node_modules/.bin/depcheck",
+      "node_modules/.bin/ejs",
+      "node_modules/.bin/ember-template-lint",
+      "node_modules/.bin/ember-template-recast",
+      "node_modules/.bin/escodegen",
+      "node_modules/.bin/esgenerate",
+      "node_modules/.bin/eslint",
+      "node_modules/.bin/eslint-config-prettier",
+      "node_modules/.bin/esparse",
+      "node_modules/.bin/esvalidate",
+      "node_modules/.bin/flat",
+      "node_modules/.bin/gonzales",
+      "node_modules/.bin/handlebars",
+      "node_modules/.bin/he",
+      "node_modules/.bin/highlight",
+      "node_modules/.bin/import-local-fixture",
+      "node_modules/.bin/is-ci",
+      "node_modules/.bin/is-docker",
+      "node_modules/.bin/jake",
+      "node_modules/.bin/jest",
+      "node_modules/.bin/jest-runtime",
+      "node_modules/.bin/js-yaml",
+      "node_modules/.bin/jsesc",
+      "node_modules/.bin/json5",
+      "node_modules/.bin/lerna-changelog",
+      "node_modules/.bin/mkdirp",
+      "node_modules/.bin/node-which",
+      "node_modules/.bin/npm-check",
+      "node_modules/.bin/parser",
+      "node_modules/.bin/prettier",
+      "node_modules/.bin/rc",
+      "node_modules/.bin/regexp-tree",
+      "node_modules/.bin/release-it",
+      "node_modules/.bin/rimraf",
+      "node_modules/.bin/sane",
+      "node_modules/.bin/semver",
+      "node_modules/.bin/shjs",
+      "node_modules/.bin/sloc",
+      "node_modules/.bin/specificity",
+      "node_modules/.bin/sshpk-conv",
+      "node_modules/.bin/sshpk-sign",
+      "node_modules/.bin/sshpk-verify",
+      "node_modules/.bin/strip-indent",
+      "node_modules/.bin/stylelint",
+      "node_modules/.bin/ts-jest",
+      "node_modules/.bin/tsc",
+      "node_modules/.bin/tsserver",
+      "node_modules/.bin/uglifyjs",
+      "node_modules/.bin/uuid",
+      "node_modules/.bin/watch",
+      "node_modules/.yarn-integrity",
+      "package.json",
+      "src/checkup-plugin-embroider/index.ts",
+      "src/checkup-plugin-embroider/package.json",
+      "src/checkup-plugin-embroider/tasks/dependency-check-task.ts",
+      "src/markdown-formatter.ts",
+      "src/stitch.ts",
+      "src/templates/embroider-preflight.md",
+      "tsconfig.json",
+      "types/ejs.d.ts",
+      "yarn.lock"
+    ],
+    "analyzedFilesCount": 104,
+    "actions": [],
+    "timings": {
+      "embroider/dependency-check": 0.000036658
+    }
+  },
+  "runs": [
+    {
+      "results": [
+        {
+          "message": {
+            "text": "Current version of ember-a11y-testing isn't compatible with Embroider"
+          },
+          "ruleId": "dependency-check",
+          "properties": {
+            "taskDisplayName": "Dependency Check",
+            "category": "embroider",
+            "stitchResult": {
+              "packageName": "ember-a11y-testing",
+              "packageVersion": "^2.0.1",
+              "packageBreadcrumb": [
+                "my-project",
+                "ember-a11y-testing"
+              ]
+            }
+          }
+        }
+      ],
+      "invocations": [
+        {
+          "arguments": [
+            "--config.$schema",
+            "https://raw.githubusercontent.com/checkupjs/checkup/master/packages/core/src/schemas/config-schema.json",
+            "--config.plugins",
+            "checkup-plugin-embroider",
+            "--cwd",
+            "/Users/foo/stitch",
+            "--pluginBaseDir",
+            "/Users/foo/stitch/lib"
+          ],
+          "executionSuccessful": true,
+          "endTimeUtc": "2021-05-24T20:41:05.686Z",
+          "toolExecutionNotifications": [],
+          "startTimeUtc": "2021-05-24T20:41:05.588Z"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "Checkup",
+          "rules": [
+            {
+              "id": "dependency-check",
+              "shortDescription": {
+                "text": "Dependency Check"
+              },
+              "properties": {
+                "enabled": true,
+                "category": "embroider"
+              }
+            }
+          ],
+          "language": "en-US",
+          "informationUri": "https://github.com/checkupjs/checkup",
+          "version": "1.0.0-beta.11"
+        }
+      }
+    }
+  ]
+}

--- a/__tests__/__utils__/tmp-dir.ts
+++ b/__tests__/__utils__/tmp-dir.ts
@@ -1,0 +1,6 @@
+import { realpathSync } from 'fs';
+import tmp = require('tmp');
+
+export function createTmpDir(): string {
+  return realpathSync(tmp.dirSync({ unsafeCleanup: true }).name);
+}

--- a/__tests__/markdown-formatter-test.ts
+++ b/__tests__/markdown-formatter-test.ts
@@ -1,0 +1,71 @@
+import { readJsonSync } from 'fs-extra';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { createTmpDir } from './__utils__/tmp-dir';
+import MarkdownFormatter from '../src/markdown-formatter';
+
+const ROOT = process.cwd();
+
+describe('markdown-formatter-test', () => {
+  let tmp: string;
+
+  beforeEach(function () {
+    tmp = createTmpDir();
+  });
+
+  afterEach(function () {
+    process.chdir(ROOT);
+  });
+
+  it('can create a markdown report in the specific directory without results', () => {
+    const outputPath = join(tmp, 'embroider-preflight.md');
+    const formatter = new MarkdownFormatter({
+      cwd: tmp,
+    });
+    const results = readJsonSync(join(__dirname, '__fixtures__', 'markdown-results.sarif'));
+
+    // explicitly remove all results
+    results.runs[0].results = [];
+
+    formatter.format(results);
+
+    expect(existsSync(outputPath)).toEqual(true);
+    expect(readFileSync(outputPath, { encoding: 'utf-8' })).toMatchInlineSnapshot(`
+      "# Embroider Preflight Report for Fake Project
+
+      ## Preflight Check Results
+
+
+      All packages are compatible!
+      "
+    `);
+  });
+
+  it('can create a markdown report in the specific directory with results', () => {
+    const outputPath = join(tmp, 'embroider-preflight.md');
+    const formatter = new MarkdownFormatter({
+      cwd: tmp,
+    });
+    const results = readJsonSync(join(__dirname, '__fixtures__', 'markdown-results.sarif'));
+
+    formatter.format(results);
+
+    expect(existsSync(outputPath)).toEqual(true);
+    expect(readFileSync(outputPath, { encoding: 'utf-8' })).toMatchInlineSnapshot(`
+      "# Embroider Preflight Report for Fake Project
+
+      ## Preflight Check Results
+
+
+      The following packages are not compatible with Embroider.
+
+      ### ember-a11y-testing
+      <details>
+        <summary>Package paths</summary>
+        my-project &gt; ember-a11y-testing
+      </details>
+
+      "
+    `);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "/lib"
   ],
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && yarn copy-files",
+    "copy-files": "cp -R ./src/templates ./lib",
     "lint": "eslint . --cache --ext .ts",
     "prepare": "yarn build",
     "test": "jest --runInBand"
@@ -25,6 +26,7 @@
   "dependencies": {
     "@checkup/cli": "^1.0.0-beta.11",
     "@checkup/core": "^1.0.0-beta.11",
+    "ejs": "^3.1.6",
     "ora": "^5.4.0",
     "v8-compile-cache": "^2.3.0",
     "yargs": "^16.2.0"
@@ -35,6 +37,8 @@
     "@microsoft/jest-sarif": "^1.0.0-beta.0",
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.23",
+    "@types/sarif": "^2.1.3",
+    "@types/tmp": "^0.2.0",
     "@types/yargs": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
@@ -52,6 +56,7 @@
     "prettier": "^2.3.0",
     "release-it": "^14.2.1",
     "release-it-lerna-changelog": "^3.1.0",
+    "tmp": "^0.2.1",
     "ts-jest": "^26.5.6",
     "typescript": "^4.2.4"
   },

--- a/src/markdown-formatter.ts
+++ b/src/markdown-formatter.ts
@@ -1,0 +1,49 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import * as ejs from 'ejs';
+import { FormatterArgs } from '@checkup/core';
+import type { Log } from 'sarif';
+
+type MarkdownFormatterArgs = Omit<FormatterArgs, 'format' | 'writer'>;
+
+export default class MarkdownFormatter {
+  args: MarkdownFormatterArgs;
+
+  private get template(): string {
+    return readFileSync(join(__dirname, 'templates', 'embroider-preflight.md.ejs'), {
+      encoding: 'utf-8',
+    });
+  }
+
+  constructor(args: MarkdownFormatterArgs) {
+    this.args = args;
+  }
+
+  format(result: Log): void {
+    const outputPath = join(this.args.cwd, 'embroider-preflight.md');
+    const markdownReport = ejs.render(this.template, {
+      projectName: 'Fake Project',
+      results: this.getResults(result),
+    });
+
+    writeFileSync(outputPath, markdownReport);
+  }
+
+  private getResults(result: Log) {
+    const results = result.runs[0].results;
+
+    if (!results) {
+      return [];
+    }
+
+    return results.map((result) => {
+      const stitchResult = result?.properties?.stitchResult;
+
+      return {
+        packageName: stitchResult.packageName,
+        packageVersion: stitchResult.packageVersion,
+        packageBreadcrumb: stitchResult.packageBreadcrumb,
+      };
+    });
+  }
+}

--- a/src/templates/embroider-preflight.md.ejs
+++ b/src/templates/embroider-preflight.md.ejs
@@ -1,0 +1,16 @@
+# Embroider Preflight Report for <%= projectName %>
+
+## Preflight Check Results
+
+<% if (results.length > 0) { %>
+The following packages are not compatible with Embroider.
+<% results.forEach((result) => { %>
+### <%= result.packageName %>
+<details>
+  <summary>Package paths</summary>
+  <%= result.packageBreadcrumb.join(' > ') %>
+</details>
+<% }); %>
+<% } else { %>
+All packages are compatible!
+<% } %>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
       "*": ["./types/*"]
     }
   },
-  "include": ["./src", "./src/checkup-plugin-embroider/package.json"],
+  "include": ["./src/**/*", "./src/checkup-plugin-embroider/package.json"],
   "exclude": ["**/node_modules/**"]
 }

--- a/types/ejs.d.ts
+++ b/types/ejs.d.ts
@@ -1,0 +1,1 @@
+declare module 'ejs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,6 +1143,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/tmp@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
+  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
+
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -2861,7 +2866,7 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-ejs@^3.1.5:
+ejs@^3.1.5, ejs@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
   integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==


### PR DESCRIPTION
This PR adds markdown output functionality to enable the `preflight` command to render the SARIF results into markdown. It uses `ejs`, simply because it's easier to format the markdown the way you want it when in a template file vs. strings.