### PR TITLE
Enable stitch to pass arguments to tasks

### DIFF
--- a/src/checkup-plugin-embroider/tasks/dependency-check-task.ts
+++ b/src/checkup-plugin-embroider/tasks/dependency-check-task.ts
@@ -14,7 +14,6 @@ export default class DependencyCheck extends BaseTask implements Task {
   category = 'embroider';
 
   async run(): Promise<Result[]> {
-    debugger;
     const packageCompatibility: PackageCheck = packageCompatibilityJSON;
     const pkgs = await findBadPackages(this.context.options.cwd, packageCompatibility);
     const results = [];

--- a/src/checkup-plugin-embroider/tasks/dependency-check-task.ts
+++ b/src/checkup-plugin-embroider/tasks/dependency-check-task.ts
@@ -14,13 +14,18 @@ export default class DependencyCheck extends BaseTask implements Task {
   category = 'embroider';
 
   async run(): Promise<Result[]> {
-    const packageCompatibility: PackageCheck  = packageCompatibilityJSON;
+    debugger;
+    const packageCompatibility: PackageCheck = packageCompatibilityJSON;
     const pkgs = await findBadPackages(this.context.options.cwd, packageCompatibility);
     const results = [];
 
     for (const pkg of pkgs) {
       results.push({
-        message: { text: `Detected version of ${pkg.packageName} as ${pkg.packageVersion} but ${packageCompatibility[pkg.packageName]} found in ${pkg.packageBreadcrumb.join(' > ')}.` },
+        message: {
+          text: `Detected version of ${pkg.packageName} as ${pkg.packageVersion} but ${
+            packageCompatibility[pkg.packageName]
+          } found in ${pkg.packageBreadcrumb.join(' > ')}.`,
+        },
         ruleId: this.taskName,
         properties: {
           taskDisplayName: this.taskDisplayName,
@@ -28,8 +33,8 @@ export default class DependencyCheck extends BaseTask implements Task {
           stitchResult: {
             packageName: pkg.packageName,
             packageVersion: pkg.packageVersion,
-            packageBreadcrumb: pkg.packageBreadcrumb
-          }
+            packageBreadcrumb: pkg.packageBreadcrumb,
+          },
         },
       });
     }

--- a/src/stitch.ts
+++ b/src/stitch.ts
@@ -5,6 +5,7 @@ import * as yargs from 'yargs';
 
 interface StitchArguments {
   workingDirectory: string;
+  fooBar: string;
 }
 
 type Options = StitchArguments & yargs.Arguments;
@@ -34,6 +35,10 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
             // are fairly deep)
             default: '.',
           },
+          'foo-bar': {
+            describe: 'An example of threading arguments through to tasks',
+            type: 'string',
+          },
         });
       },
       handler: async (options: Options) => {
@@ -46,10 +51,14 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
           $schema: CONFIG_SCHEMA_URL,
           excludePaths: [],
           plugins: ['checkup-plugin-embroider'],
-          tasks: {},
+          tasks: {
+            'embroider/dependency-check': ['on', { fooBar: options.fooBar }],
+          },
         };
 
         const taskRunner = new CheckupTaskRunner({
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           config,
           cwd: options.workingDirectory,
           pluginBaseDir: __dirname,


### PR DESCRIPTION
Simple example of demonstrating how to pass argument through to Checkup tasks. The top-level argument, `foo-bar` is threaded through the Checkup config (ignore the @ts-ignore for now, there's something odd with the types so just ignoring for now), and is accessed inside the task via `this.config`. 