### PR TITLE
Add pretty reporter and --format option

### DIFF
--- a/__tests__/cli-test.ts
+++ b/__tests__/cli-test.ts
@@ -51,7 +51,6 @@ describe('cli-test', () => {
 
   it('can invoke the preflight command using the pretty formatter', async () => {
     const result = await run(['preflight', '--format', 'pretty']);
-    debugger;
 
     expect(result.exitCode).toEqual(0);
     expect(result.stdout).toMatchInlineSnapshot(`

--- a/__tests__/cli-test.ts
+++ b/__tests__/cli-test.ts
@@ -1,4 +1,5 @@
 import '@microsoft/jest-sarif';
+import { readFileSync } from 'fs';
 import execa from 'execa';
 import { Project } from 'fixturify-project';
 
@@ -8,7 +9,10 @@ describe('cli-test', () => {
   let project: Project;
 
   beforeEach(function () {
-    project = new Project('fake-project', '0.0.1');
+    project = new Project('fake-project', '0.0.1', (p) => {
+      p.addDevDependency('@ember/test-waiters', '2.0.0');
+      p.addDevDependency('ember-cli-fastboot', '2.0.0');
+    });
     project.writeSync();
   });
 
@@ -37,11 +41,29 @@ describe('cli-test', () => {
     `);
   });
 
-  it('can invoke the preflight command', async () => {
+  it('can invoke the preflight command using the default markdown formatter', async () => {
     const result = await run(['preflight']);
 
     expect(result.exitCode).toEqual(0);
-    expect(JSON.parse(result.stdout)).toBeValidSarifLog();
+    expect(result.stdout).toMatch(
+      /Embroider preflight check written to .*\/embroider-preflight.md/
+    );
+  });
+
+  it('can invoke the preflight command using the pretty formatter', async () => {
+    const result = await run(['preflight', '--format', 'pretty']);
+    debugger;
+
+    expect(result.exitCode).toEqual(0);
+    expect(result.stdout).toMatchInlineSnapshot(`
+      "## Preflight Check Results
+
+      The following packages are not compatible with Embroider.
+      @ember/test-waiters
+        - fake-project
+      ember-cli-fastboot
+        - fake-project"
+    `);
   });
 
   it('can invoke the migrate command', async () => {

--- a/__tests__/cli-test.ts
+++ b/__tests__/cli-test.ts
@@ -1,5 +1,4 @@
 import '@microsoft/jest-sarif';
-import { readFileSync } from 'fs';
 import execa from 'execa';
 import { Project } from 'fixturify-project';
 

--- a/__tests__/formatters/markdown-test.ts
+++ b/__tests__/formatters/markdown-test.ts
@@ -1,8 +1,8 @@
 import { readJsonSync } from 'fs-extra';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { createTmpDir } from './__utils__/tmp-dir';
-import MarkdownFormatter from '../src/markdown-formatter';
+import { createTmpDir } from '../__utils__/tmp-dir';
+import MarkdownFormatter from '../../src/formatters/markdown';
 
 const ROOT = process.cwd();
 
@@ -22,7 +22,7 @@ describe('markdown-formatter-test', () => {
     const formatter = new MarkdownFormatter({
       cwd: tmp,
     });
-    const results = readJsonSync(join(__dirname, '__fixtures__', 'markdown-results.sarif'));
+    const results = readJsonSync(join(__dirname, '..', '__fixtures__', 'markdown-results.sarif'));
 
     // explicitly remove all results
     results.runs[0].results = [];
@@ -46,7 +46,7 @@ describe('markdown-formatter-test', () => {
     const formatter = new MarkdownFormatter({
       cwd: tmp,
     });
-    const results = readJsonSync(join(__dirname, '__fixtures__', 'markdown-results.sarif'));
+    const results = readJsonSync(join(__dirname, '..', '__fixtures__', 'markdown-results.sarif'));
 
     formatter.format(results);
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "copy-files": "cp -R ./src/templates ./lib && cp -R src/codemods ./lib",
     "lint": "eslint . --cache --ext .ts",
     "prepare": "yarn build",
-    "test": "jest --runInBand --silent"
+    "test": "jest --runInBand"
   },
   "resolutions": {
     "resolve-package-path": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "copy-files": "cp -R ./src/templates ./lib && cp -R src/codemods ./lib",
     "lint": "eslint . --cache --ext .ts",
     "prepare": "yarn build",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --silent"
   },
   "resolutions": {
     "resolve-package-path": "^4.0.0"

--- a/src/formatters/markdown.ts
+++ b/src/formatters/markdown.ts
@@ -1,32 +1,32 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import * as ejs from 'ejs';
-import { FormatterArgs } from '@checkup/core';
 import type { Log } from 'sarif';
-
-type MarkdownFormatterArgs = Omit<FormatterArgs, 'format' | 'writer'>;
+import type { StitchFormatterArgs } from '../types/formatter';
 
 export default class MarkdownFormatter {
-  args: MarkdownFormatterArgs;
+  args: StitchFormatterArgs;
 
   private get template(): string {
-    return readFileSync(join(__dirname, 'templates', 'embroider-preflight.md.ejs'), {
+    return readFileSync(join(__dirname, '..', 'templates', 'embroider-preflight.md.ejs'), {
       encoding: 'utf-8',
     });
   }
 
-  constructor(args: MarkdownFormatterArgs) {
+  constructor(args: StitchFormatterArgs) {
     this.args = args;
   }
 
-  format(result: Log): void {
+  format(log: Log): void {
     const outputPath = join(this.args.cwd, 'embroider-preflight.md');
     const markdownReport = ejs.render(this.template, {
       projectName: 'Fake Project',
-      results: this.getResults(result),
+      results: this.getResults(log),
     });
 
     writeFileSync(outputPath, markdownReport);
+
+    process.stdout.write(`Embroider preflight check written to ${outputPath}`);
   }
 
   private getResults(result: Log) {

--- a/src/formatters/pretty.ts
+++ b/src/formatters/pretty.ts
@@ -1,0 +1,39 @@
+import { Log } from 'sarif';
+import type { StitchFormatterArgs } from '../types/formatter';
+
+export default class PrettyFormatter {
+  args: StitchFormatterArgs;
+
+  constructor(args: StitchFormatterArgs) {
+    this.args = args;
+  }
+
+  format(log: Log): void {
+    const groupedByPackage = new Map();
+    const results = log.runs[0].results || [];
+
+    for (const result of results) {
+      const stitchResult = result.properties?.stitchResult;
+
+      if (!groupedByPackage.has(stitchResult.packageName)) {
+        groupedByPackage.set(stitchResult.packageName, []);
+      }
+
+      groupedByPackage.get(stitchResult.packageName).push(stitchResult.packageBreadcrumb);
+    }
+
+    if (groupedByPackage.size > 0) {
+      console.log('## Preflight Check Results');
+      console.log('');
+      console.log('The following packages are not compatible with Embroider.');
+
+      for (const [packageName, breadcrumbs] of groupedByPackage) {
+        console.log(packageName);
+
+        for (const breadcrumb of breadcrumbs) {
+          console.log(`  - ${breadcrumb.join(' > ')}`);
+        }
+      }
+    }
+  }
+}

--- a/src/stitch.ts
+++ b/src/stitch.ts
@@ -1,11 +1,14 @@
-import { CheckupTaskRunner, getFormatter } from '@checkup/cli';
-import { CONFIG_SCHEMA_URL, OutputFormat } from '@checkup/core';
+import { CheckupTaskRunner } from '@checkup/cli';
+import { CONFIG_SCHEMA_URL } from '@checkup/core';
 import ora from 'ora';
 import * as yargs from 'yargs';
+import MarkdownFormatter from './formatters/markdown';
+import PrettyFormatter from './formatters/pretty';
 
 interface StitchArguments {
   workingDirectory: string;
   fooBar: string;
+  format: 'pretty' | 'markdown';
 }
 
 type Options = StitchArguments & yargs.Arguments;
@@ -39,6 +42,14 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
             describe: 'An example of threading arguments through to tasks',
             type: 'string',
           },
+          format: {
+            alias: 'f',
+            describe: 'The format stitch results will be outputed with.',
+            options: ['pretty', 'markdown'],
+            default: 'markdown',
+          },
+            default: 'markdown',
+          },
         });
       },
       handler: async (options: Options) => {
@@ -65,11 +76,13 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         });
 
         const result = await taskRunner.run();
-
-        const formatter = getFormatter({
+        const formatterArgs = {
           cwd: options.workingDirectory,
-          format: OutputFormat.json,
-        });
+        };
+        const formatter =
+          options.format === 'markdown'
+            ? new MarkdownFormatter(formatterArgs)
+            : new PrettyFormatter(formatterArgs);
 
         spinner.stop();
         formatter.format(result);

--- a/src/stitch.ts
+++ b/src/stitch.ts
@@ -48,8 +48,6 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
             options: ['pretty', 'markdown'],
             default: 'markdown',
           },
-            default: 'markdown',
-          },
         });
       },
       handler: async (options: Options) => {

--- a/src/types/formatter.ts
+++ b/src/types/formatter.ts
@@ -1,0 +1,3 @@
+import { FormatterArgs } from '@checkup/core';
+
+export type StitchFormatterArgs = Omit<FormatterArgs, 'format' | 'writer'>;


### PR DESCRIPTION
Adds new `--format` option, and provides two formatters
- `markdown` - default formatter that writes to a md file
- `pretty` - outputs to the console